### PR TITLE
php関連のパッケージ更新／Dockerfileの整理

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,6 @@ FROM amazonlinux:2016.09.1.20161221
 RUN echo "OS dependencies" && \
     yum -y install vim-enhanced bash-completion unzip && \
     echo "NETWORKING=yes" > /etc/sysconfig/network && \
-    echo "Apache dependencies" && \
-    yum -y install httpd mod_ssl && \
-    echo "MySQL dependencies" && \
-    yum -y install mysql mysql-server && \
-    echo "PHP dependencies" && \
-    yum install -y php php-mysql php-devel php-gd php-pecl-memcache php-pspell php-snmp php-xmlrpc php-xml php-mbstring php-intl && \
-    echo "Start mysqld to create initial tables" && \
-    service mysqld start && \
     echo "Supervisord dependencies" && \
     yum install python27 && \
     curl https://bootstrap.pypa.io/ez_setup.py | /usr/bin/python27 && \
@@ -19,6 +11,17 @@ RUN echo "OS dependencies" && \
     source ~/.bashrc && \
     pip install pip --upgrade && \
     pip install supervisor
+
+RUN echo "Apache dependencies" && \
+    yum -y install httpd24 mod24_ssl
+
+RUN echo "MySQL dependencies" && \
+    yum -y install mysql mysql-server && \
+    echo "Start mysqld to create initial tables" && \
+    service mysqld start
+
+RUN echo "PHP dependencies" && \
+    yum install -y  php70 php70-mysqlnd php70-cli php70-pdo php70-mbstring php70-gd php70-intl php70-json php70-opcache php70-mcrypt php70-zip
 
 RUN echo "Directory setup" && \
     mkdir -p /home/develop/logs && \


### PR DESCRIPTION
php、mysql、apache関連の設定項目を分けました。
なお、httpdも2.2から2.4へ、phpは5.3から7.0にアップデートされています。
RUNコマンドをわけたのは、万が一phpのパッケージが不足している場合など、リビルド時の高速化のためです。